### PR TITLE
Fix intel power gadget bug on windows

### DIFF
--- a/carbonai/power_gadget.py
+++ b/carbonai/power_gadget.py
@@ -393,6 +393,12 @@ class PowerGadgetWin(PowerGadget):
         file_names.sort(
             key=lambda f: list(map(int, re.split(r"-|_|\.|/", f)[-7:-1]))
         )
+        if len(file_names) < 1:
+            LOGGER.warning(
+                "Didn't find any powerlog to process. "
+                "We checked in the folder %s.",
+                str(HOME_DIR / "Documents"),
+            )
         return Path(file_names[-1])
 
     def get_process_usage(self, interval=1):
@@ -416,7 +422,7 @@ class PowerGadgetWin(PowerGadget):
             )
             self.stop_thread()
         _ = subprocess.Popen(
-            '"' + str(self.powerlog_path) + '" /min',
+            'start /MIN "" "' + str(self.powerlog_path) + '"',
             stdin=None,
             stdout=None,
             stderr=None,

--- a/carbonai/power_gadget.py
+++ b/carbonai/power_gadget.py
@@ -258,7 +258,7 @@ class PowerGadgetMac(PowerGadget):
     Mac OS X custom PowerGadget wrapper.
     """
 
-    def __init__(self, powerlog_path=""):
+    def __init__(self, powerlog_path="", powerlog_save_path=""):
         super().__init__()
         if powerlog_path:
             self.powerlog_path = Path(powerlog_path)
@@ -275,12 +275,12 @@ class PowerGadgetMac(PowerGadget):
                 f"{powerlog_path}, try passing the path to "
                 "the powerLog tool to the powerMeter."
             )
-        self.powerlog_file = self.__get_powerlog_file()
+        if powerlog_save_path:
+            self.powerlog_save_path = Path(powerlog_save_path)
+        else:
+            self.powerlog_save_path = PACKAGE_PATH / MAC_INTELPOWERLOG_FILENAME
         # self.thread = None
         self.power_draws = []
-
-    def __get_powerlog_file(self):
-        return PACKAGE_PATH / MAC_INTELPOWERLOG_FILENAME
 
     def __get_power_consumption(self, duration=1, resolution=500):
         """
@@ -304,12 +304,12 @@ class PowerGadgetMac(PowerGadget):
                 "-duration",
                 str(duration),
                 "-file",
-                self.powerlog_file,
+                self.powerlog_save_path,
             ],
             stdout=open(os.devnull, "wb"),
             check=True,
         )
-        consumption = self.parse_log(self.powerlog_file)
+        consumption = self.parse_log(self.powerlog_save_path)
         return consumption
 
     def __append_energy_usage(self, process, interval=1):
@@ -363,7 +363,7 @@ class PowerGadgetWin(PowerGadget):
     Windows custom PowerGadget wrapper.
     """
 
-    def __init__(self, powerlog_path=""):
+    def __init__(self, powerlog_path="", powerlog_save_path=""):
         super().__init__()
         if powerlog_path:
             self.powerlog_path = Path(powerlog_path)
@@ -383,12 +383,21 @@ class PowerGadgetWin(PowerGadget):
                 f"{self.powerlog_path}, try passing the path to the "
                 "powerLog tool to the powerMeter."
             )
+
+        if powerlog_save_path:
+            self.powerlog_save_path = Path(powerlog_save_path)
+        else:
+            self.powerlog_save_path = Path(HOME_DIR) / "Documents"
+        if not self.powerlog_save_path.exists():
+            raise FileNotFoundError(
+                "We didn't find the save path you provided."
+            )
         self.thread = None
         self.process_usage = []
 
     def __get_powerlog_file(self):
         file_names = glob.glob(
-            str(HOME_DIR / "Documents" / WIN_INTELPOWERLOG_FILENAME)
+            str(self.powerlog_save_path / WIN_INTELPOWERLOG_FILENAME)
         )
         file_names.sort(
             key=lambda f: list(map(int, re.split(r"-|_|\.|/", f)[-7:-1]))
@@ -397,7 +406,7 @@ class PowerGadgetWin(PowerGadget):
             LOGGER.warning(
                 "Didn't find any powerlog to process. "
                 "We checked in the folder %s.",
-                str(HOME_DIR / "Documents"),
+                str(self.powerlog_save_path),
             )
         return Path(file_names[-1])
 

--- a/carbonai/power_meter.py
+++ b/carbonai/power_meter.py
@@ -79,6 +79,9 @@ class PowerMeter:
         The name of the user using the tool (for logging purpose).
     cpu_power_log_path : str, optional
         The path to the tool "PowerLog" or "powercap" or "IntelPowerGadget".
+    powerlog_save_path: str, optional
+        Path to the folder where we should find the logs provided by
+        IntelPowerGadget.
     get_country : bool, default True
         Whether to retrieve user country location or not (uses the user IP).
     location : str, optional
@@ -145,6 +148,7 @@ class PowerMeter:
         client_name="",
         user_name="",
         cpu_power_log_path="",
+        powerlog_save_path="",
         get_country=True,
         location="",
         is_online=True,
@@ -162,7 +166,8 @@ class PowerMeter:
             "": NoPowerGadget,
         }
         self.power_gadget = powergadget_platform[self.platform](
-            powerlog_path=cpu_power_log_path
+            powerlog_path=cpu_power_log_path,
+            powerlog_save_path=powerlog_save_path,
         )
 
         self.pue = self.__set_pue()
@@ -299,7 +304,9 @@ class PowerMeter:
             return self.LAPTOP_PUE  # pue for my laptop
         return self.SERVER_PUE  # pue for a server
 
-    def __set_powergadget_linux(self, powerlog_path=None):
+    def __set_powergadget_linux(
+        self, powerlog_path=None, powerlog_save_path=None
+    ):
         if POWERLOG_PATH_LINUX.exists():
             power_gadget = PowerGadgetLinuxRAPL()
         # The user needs to be root to use MSR interface


### PR DESCRIPTION
* Fix a bug that did not start the program Intel Power Gadget on some windows environments.
* Check if a powerlog file exists before opening it
* Add an argument to set the output path from intel power gadget